### PR TITLE
Add support for reloads with online players

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,19 @@
     <name>Pledge</name>
     <packaging>jar</packaging>
 
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- Spigot -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Netty -->

--- a/src/main/java/dev/thomazz/pledge/PledgeImpl.java
+++ b/src/main/java/dev/thomazz/pledge/PledgeImpl.java
@@ -71,6 +71,9 @@ public final class PledgeImpl implements Pledge {
             e.printStackTrace();
         }
 
+        // Inject into currently online players (for reloads)
+        Bukkit.getOnlinePlayers().forEach(player -> PledgeImpl.INSTANCE.getTransactionManager().createTransactionHandler(player));
+
         this.running = true;
         this.transactionManager.start(plugin);
     }
@@ -79,6 +82,8 @@ public final class PledgeImpl implements Pledge {
     public void destroy() {
         try {
             this.injector.eject();
+            // Remove handlers (for reloads)
+            Bukkit.getOnlinePlayers().forEach(this.transactionManager::removeTransactionHandler);
         } catch (Exception e) {
             PledgeImpl.LOGGER.severe("Exception encountered when trying to eject!");
             e.printStackTrace();

--- a/src/main/java/dev/thomazz/pledge/transaction/TransactionManager.java
+++ b/src/main/java/dev/thomazz/pledge/transaction/TransactionManager.java
@@ -10,6 +10,8 @@ import io.netty.channel.Channel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.netty.channel.ChannelHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -69,6 +71,19 @@ public class TransactionManager {
             this.transactionHandlers.add(handler);
         } catch (Exception e) {
             PledgeImpl.LOGGER.severe("Could not create a transaction handler for " + player.getName() + "!");
+            e.printStackTrace();
+        }
+    }
+
+    public void removeTransactionHandler(Player player) {
+        try {
+            Channel channel = MinecraftUtil.getChannelFromPlayer(player);
+
+            // Remove handler from players
+            channel.pipeline().remove("pledge_packet_handler");
+            this.transactionHandlers.removeIf(transactionHandler -> transactionHandler.getPlayer().equals(player));
+        } catch (Exception e) {
+            PledgeImpl.LOGGER.severe("Could not remove a transaction handler for " + player.getName() + "!");
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
Whilst testing I found that Pledge would not begin sending transaction packets until relogging into the server after performing a reload on a plugin using Pledge.

This injects into all current online players when Pledge is started and removes itself from all players when the Pledge#destroy method is called (otherwise you will get a duplicate handler name error when starting again).

Also additionally added the Spigot repository (and bumped version from .4 to .5), because that was missing.

Tested on 1.17.1 Paper using Plugman to reload.