### PR TITLE
Fix memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.thomazz</groupId>
     <artifactId>pledge</artifactId>
-    <version>2.7</version>
+    <version>2.8</version>
     <name>Pledge</name>
     <packaging>jar</packaging>
 

--- a/src/main/java/dev/thomazz/pledge/api/event/PacketFlushEvent.java
+++ b/src/main/java/dev/thomazz/pledge/api/event/PacketFlushEvent.java
@@ -1,5 +1,6 @@
 package dev.thomazz.pledge.api.event;
 
+import dev.thomazz.pledge.network.QueuedMessage;
 import lombok.Getter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -16,9 +17,9 @@ public class PacketFlushEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
 
     private final Player player;
-    private final Queue<Object> packets;
+    private final Queue<QueuedMessage> packets;
 
-    public PacketFlushEvent(Player player, Queue<Object> packets) {
+    public PacketFlushEvent(Player player, Queue<QueuedMessage> packets) {
         super(true);
         this.player = player;
         this.packets = packets;

--- a/src/main/java/dev/thomazz/pledge/network/QueuedMessage.java
+++ b/src/main/java/dev/thomazz/pledge/network/QueuedMessage.java
@@ -1,0 +1,12 @@
+package dev.thomazz.pledge.network;
+
+import io.netty.channel.ChannelPromise;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class QueuedMessage {
+    private final Object packet;
+    private final ChannelPromise promise;
+}


### PR DESCRIPTION
There is a memory leak with DefaultChannelPromise, because Pledge ignores the promises and thus they are never completed. After this change, the problem is fixed and it never appears in heap summaries. Have been using this fix for a few days without any issues.

This does have a breaking API change - I changed it for simplicity and performance.
![image](https://github.com/ThomasOM/Pledge/assets/11319274/20bafb90-5eb7-434f-9913-649e1931c6a8)
