### PR TITLE
Add skip frame API and hot reload support fixes

### DIFF
--- a/src/main/java/dev/thomazz/pledge/PledgeImpl.java
+++ b/src/main/java/dev/thomazz/pledge/PledgeImpl.java
@@ -87,7 +87,9 @@ public class PledgeImpl implements Pledge, Listener {
         this.clientPingers.forEach(pinger -> pinger.unregisterPlayer(player));
 
         // Unregister pong listener
-        ChannelAccess.getChannel(player).pipeline().remove("pledge_packet_listener");
+        getChannel(player).ifPresent(channel -> {
+            channel.pipeline().remove("pledge_packet_listener");
+        });
 
         this.playerChannels.remove(player);
     }
@@ -99,6 +101,7 @@ public class PledgeImpl implements Pledge, Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     void onPlayerQuit(PlayerQuitEvent event) {
+        this.playerChannels.remove(event.getPlayer());
         this.teardownPlayer(event.getPlayer());
     }
 

--- a/src/main/java/dev/thomazz/pledge/PledgeImpl.java
+++ b/src/main/java/dev/thomazz/pledge/PledgeImpl.java
@@ -83,10 +83,13 @@ public class PledgeImpl implements Pledge, Listener {
     }
 
     private void teardownPlayer(Player player) {
-        this.playerChannels.remove(player);
-
         // Unregister from client pingers
         this.clientPingers.forEach(pinger -> pinger.unregisterPlayer(player));
+
+        // Unregister pong listener
+        ChannelAccess.getChannel(player).pipeline().remove("pledge_packet_listener");
+
+        this.playerChannels.remove(player);
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/dev/thomazz/pledge/pinger/frame/FrameClientPinger.java
+++ b/src/main/java/dev/thomazz/pledge/pinger/frame/FrameClientPinger.java
@@ -25,4 +25,11 @@ public interface FrameClientPinger extends ClientPinger {
      * @param listener - Listener to attach
      */
     void attach(FrameClientPingerListener listener);
+
+    /**
+     * Forcefully end the current frame and move to the next Frame
+     * <p>
+     * @param player - Player to end frame for
+     */
+    void nextFrame(Player player);
 }

--- a/src/main/java/dev/thomazz/pledge/pinger/frame/FrameClientPingerImpl.java
+++ b/src/main/java/dev/thomazz/pledge/pinger/frame/FrameClientPingerImpl.java
@@ -93,9 +93,9 @@ public class FrameClientPingerImpl extends ClientPingerImpl implements FrameClie
 
         FrameData data = this.frameDataMap.get(player);
         if (data != null && this.frameListener != null) {
-            data.matchStart(id).ifPresent(
-                frame -> this.frameListener.forEach(listener -> listener.onFrameReceiveStart(player, frame))
-            );
+            data.matchStart(id, (frame) -> {
+                this.frameListener.forEach(listener -> listener.onFrameReceiveStart(player, frame));
+            });
         }
     }
 
@@ -105,12 +105,10 @@ public class FrameClientPingerImpl extends ClientPingerImpl implements FrameClie
 
         FrameData data = this.frameDataMap.get(player);
         if (data != null && this.frameListener != null) {
-            data.matchEnd(id).ifPresent(
-                frame -> {
-                    this.frameListener.forEach(listener -> listener.onFrameReceiveEnd(player, frame));
-                    data.popFrame();
-                }
-            );
+            data.matchEnd(id, (frame -> {
+                this.frameListener.forEach(listener -> listener.onFrameReceiveEnd(player, frame));
+            }));
+            data.popFrame(id);
         }
     }
 

--- a/src/main/java/dev/thomazz/pledge/pinger/frame/FrameClientPingerImpl.java
+++ b/src/main/java/dev/thomazz/pledge/pinger/frame/FrameClientPingerImpl.java
@@ -34,6 +34,13 @@ public class FrameClientPingerImpl extends ClientPingerImpl implements FrameClie
         super.attach(listener);
         this.frameListener.add(listener);
     }
+    @Override
+    public void nextFrame(Player player) {
+        FrameData frameData = this.frameDataMap.get(player);
+        if(frameData != null) {
+            trySendPings(player, frameData);
+        }
+    }
 
     @Override
     public void registerPlayer(Player player) {

--- a/src/test/java/dev/thomazz/pledge/ClientPingerTests.java
+++ b/src/test/java/dev/thomazz/pledge/ClientPingerTests.java
@@ -110,9 +110,9 @@ public class ClientPingerTests {
         for (int i = 0; i > -400; i--) {
             Optional<Frame> frame;
             if (toggle) {
-                frame = frameData.matchStart(i);
+                frame = frameData.matchStart(i, (f) -> {});
             } else {
-                frame = frameData.matchEnd(i);
+                frame = frameData.matchEnd(i, (f) -> {});
             }
 
             if (!frame.isPresent()) {
@@ -120,7 +120,7 @@ public class ClientPingerTests {
             }
 
             if (!toggle) {
-                frameData.popFrame();
+                frameData.popFrame(i);
             }
 
             toggle = !toggle;


### PR DESCRIPTION
* Add `nextFrame()` api to allow to jump to next frame
* Fixed the duplicate handler problem caused by the channel handler not being removed correctly, which caused the hot reload to fail.